### PR TITLE
Expose HTML Swagger UI for API specs when GH pages are enabled

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+statestore-api/postman/statestore.postman.json
+tmp/

--- a/index.html
+++ b/index.html
@@ -1,0 +1,57 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <title>Swagger UI</title>
+    <link
+      href="https://fonts.googleapis.com/css?family=Open+Sans:400,700|Source+Code+Pro:300,600|Titillium+Web:400,600,700"
+      rel="stylesheet"
+    />
+    <link
+      rel="stylesheet"
+      type="text/css"
+      href="https://cdnjs.cloudflare.com/ajax/libs/swagger-ui/4.0.0/swagger-ui.css"
+    />
+    <style>
+      html {
+        box-sizing: border-box;
+        overflow: -moz-scrollbars-vertical;
+        overflow-y: scroll;
+      }
+
+      *,
+      *:before,
+      *:after {
+        box-sizing: inherit;
+      }
+
+      body {
+        margin: 0;
+        background: #fafafa;
+      }
+    </style>
+  </head>
+
+  <body>
+    <div id="swagger-ui"></div>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/swagger-ui/4.0.0/swagger-ui-bundle.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/swagger-ui/4.0.0/swagger-ui-standalone-preset.js"></script>
+    <script>
+      const ui = SwaggerUIBundle({
+        urls: [
+          {url: "statestore-api/statestore.yaml", name: "State Store APIs"},
+          {url: "pubsub-api/pubsub.yaml", name: "PubSub APIs"},
+         
+        ],
+        dom_id: "#swagger-ui",
+        deepLinking: true,
+        presets: [SwaggerUIBundle.presets.apis, SwaggerUIStandalonePreset],
+        plugins: [SwaggerUIBundle.plugins.DownloadUrl],
+        layout: "StandaloneLayout",
+        onComplete: () => {
+          console.log("Swagger UI loaded");
+        },
+      });
+    </script>
+  </body>
+</html>

--- a/www/index.html
+++ b/www/index.html
@@ -39,8 +39,8 @@
     <script>
       const ui = SwaggerUIBundle({
         urls: [
-          {url: "statestore-api/statestore.yaml", name: "State Store APIs"},
-          {url: "pubsub-api/pubsub.yaml", name: "PubSub APIs"},
+          {url: "../statestore-api/statestore.yaml", name: "State Store APIs"},
+          {url: "../pubsub-api/pubsub.yaml", name: "PubSub APIs"},
          
         ],
         dom_id: "#swagger-ui",


### PR DESCRIPTION
This PR adds the Swagger UI to be public when GH pages are enabled on this repository. 